### PR TITLE
Correct documentation of sgtelib option

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -519,7 +519,7 @@ Deactivated when the number of variables is greater than 50.
 
 `true` by default.
 
--> `sgtelib_search::Bool`:
+-> `sgtelib_model_search::Bool`:
 
 If true, the algorithm executes a model search strategy using Sgtelib at each iteration.
 Deactivated when the number of variables is greater than 50.


### PR DESCRIPTION
Alternatively, could also change the option name to `sgtelib_search` to match the other flag name patterns.